### PR TITLE
fix error handling edge case

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -51,6 +51,10 @@ module.exports = function (apiKey, chain) {
           return reject(data.message);
         }
 
+        if (data.error) {
+          return reject(data.error.message);
+        }
+
         resolve(data);
       });
     });
@@ -198,11 +202,11 @@ module.exports = function (apiKey, chain) {
        * var res = api.proxy.eth_getTransactionByHash('0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1');
        * @returns {Promise.<object>}
        */
-      eth_getTransactionByHash(hash) {
+      eth_getTransactionByHash(txhash) {
         const module = 'proxy';
         const action = 'eth_getTransactionByHash';
         var query = querystring.stringify({
-          module, action, apiKey, hash
+          module, action, apiKey, txhash
         });
         return getRequest(query);
       },
@@ -494,7 +498,7 @@ module.exports = function (apiKey, chain) {
        *     var supply = api.account.tokenbalance(
        *       '0x4366ddc115d8cf213c564da36e64c8ebaa30cdbd',
        *       'DGD',
-       *       '' 
+       *       ''
        * );
        * @returns {Promise.<object>}
        */
@@ -519,7 +523,7 @@ module.exports = function (apiKey, chain) {
         if (address) {
           queryObject.address = address;
         }
-        
+
         var query = querystring.stringify(queryObject);
         return getRequest(query);
       },


### PR DESCRIPTION
you can reproduce the error by going here: https://api.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&apiKey=ropsten&hash=0x341a97b957f7f454dcc8a231a837048e9e798e03c7e1d98e11a657a12b5d98e0

the `hash` query param should be `txhash`, and as you see the error is non-standard (error object vs status):

```json
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: expected a hex-encoded hash with 0x prefix."},"id":1}
```