### PR TITLE
Don't pass full URL in again as it is already set

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -2,12 +2,12 @@
 var restify = require('restify-clients');
 const querystring = require('querystring');
 
-const url = 'https://api.etherscan.io/api';
+const url = 'https://api.etherscan.io';
 const testUrls = {
   // old default defaults to rinkeb
-  'ropsten': 'https://ropsten.etherscan.io/api',
-  'kovan': 'https://kovan.etherscan.io/api',
-  'rinkeby': 'https://rinkeby.etherscan.io/api'
+  'ropsten': 'https://ropsten.etherscan.io',
+  'kovan': 'https://kovan.etherscan.io',
+  'rinkeby': 'https://rinkeby.etherscan.io'
 };
 
 /**
@@ -42,7 +42,7 @@ module.exports = function (apiKey, chain) {
 
   function getRequest(query) {
     var p = new Promise(function(resolve, reject) {
-      client.get(url+'?'+query, function(err, req, res, data) {
+      client.get('/api?'+query, function(err, req, res, data) {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
When creating the jsonClient, otherwise this confuses tools like `nock` when trying to match requests.