### PR TITLE
Support internal transactions by address

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -551,17 +551,37 @@ module.exports = function (apiKey, chain) {
       },
       /**
        * Get a list of internal transactions
-       * @param {string} txhash - Transaction hash
+       * @param {string} txhash - Transaction hash. If specified then address will be ignored
+       * @param {string} address - Transaction address
+       * @param {string} startblock - start looking here
+       * @param {string} endblock - end looking there
+       * @param {string} sort - Sort asc/desc
        * @example
        * var txlist = api.account.txlistinternal('0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170');
        * @returns {Promise.<object>}
        */
-      txlistinternal(txhash) {
+      txlistinternal(txhash, address, startblock, endblock, sort) {
         const module = 'account';
         const action = 'txlistinternal';
 
+        if (!startblock) {
+          startblock = 0;
+        }
+
+        if (!endblock) {
+          endblock = 'latest';
+        }
+
+        if (!sort) {
+          sort = 'asc';
+        }
+
+        if (txhash) {
+          address = undefined;
+        }
+
         var query = querystring.stringify({
-          module, action, txhash, apiKey
+          module, action, txhash, address, apiKey
         });
 
         return getRequest(query);

--- a/test/methods-test.js
+++ b/test/methods-test.js
@@ -40,9 +40,17 @@ describe('api', function() {
         done();
       });
     });
-    it('txlistinternal', function(done){
+    it('txlistinternal by hash', function(done){
       var api = init();
       var txlist = api.account.txlistinternal('0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170');
+      txlist.then(function(res){
+        assert.ok(res);
+        done();
+      });
+    });
+    it('txlistinternal b yaddress', function(done){
+      var api = init();
+      var txlist = api.account.txlistinternal(null, '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae');
       txlist.then(function(res){
         assert.ok(res);
         done();

--- a/test/testnet-methods-test.js
+++ b/test/testnet-methods-test.js
@@ -47,9 +47,17 @@ describe('testnet methods', function() {
         done();
       });
     });
-    xit('txlistinternal', function(done){
+    xit('txlistinternal by hash', function(done){
 
       var txlist = api.account.txlistinternal('0xf2aa030a0b889706206d262377cd45489faa2ff7dedbccda3693bf6c5370ed0c');
+      txlist.then(function(res){
+        assert.ok(res);
+        done();
+      });
+    });
+    xit('txlistinternal by address', function(done){
+
+      var txlist = api.account.txlistinternal(null,'0x3FAcfa472e86E3EDaEaa837f6BA038ac01F7F539');
       txlist.then(function(res){
         assert.ok(res);
         done();


### PR DESCRIPTION
Extended existing `txlistinternal` function to support fetching internal transactions by address (this is beta in the API)
Also added `txlistinternal` parameters to specify start/end block and sort order