### PR TITLE
Add tokentx action support to account module which allows getting a list of ERC20 tokes transfer events

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.etherscanApi = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.etherscanApi = f()}})(function(){var define,module,exports;return (function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s}return e})()({1:[function(require,module,exports){
 'use strict';
 const init = require('./lib/init');
 
@@ -6,654 +6,776 @@ module.exports = {
   init
 };
 
-},{"./lib/init":2}],2:[function(require,module,exports){
-"use strict";
-var axios = require('axios');
+},{"./lib/init":6}],2:[function(require,module,exports){
 const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * Returns the amount of Tokens a specific account owns.
+     * @param {string} address - Contract address
+     * @param {string} tokenname - Name of the token
+     * @param {string} contractaddress - Contract address
+     * @example
+     *     var supply = api.account.tokenbalance(
+     *       '0x4366ddc115d8cf213c564da36e64c8ebaa30cdbd',
+     *       'DGD',
+     *       ''
+     * );
+     * @returns {Promise.<object>}
+     */
+    tokenbalance(address, tokenname, contractaddress) {
 
-const url = 'https://api.etherscan.io';
-const testUrls = {
-  // old default defaults to rinkeb
-  'ropsten': 'https://ropsten.etherscan.io',
-  'kovan': 'https://kovan.etherscan.io',
-  'rinkeby': 'https://rinkeby.etherscan.io'
+      const module = 'account';
+      const action = 'tokenbalance';
+      const tag = 'latest';
+
+      var queryObject = {
+        module, action, apiKey, tag
+      };
+
+      if (contractaddress) {
+        queryObject.contractaddress = contractaddress;
+      }
+
+      if (tokenname) {
+        queryObject.tokenname = tokenname;
+      }
+
+      if (address) {
+        queryObject.address = address;
+      }
+
+      var query = querystring.stringify(queryObject);
+      return getRequest(query);
+    },
+    /**
+     * Returns the balance of a sepcific account
+     * @param {string} address - Address
+     * @example
+     * var balance = api.account.balance('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae');
+     * @returns {Promise.<object>}
+     */
+    balance(address) {
+      const module = 'account';
+      let action = 'balance';
+      const tag = 'latest';
+
+      if (typeof address !== 'string' && address && address.length) {
+        address = address.join(',');
+        action = 'balancemulti';
+      }
+
+      var query = querystring.stringify({
+        module, action, tag, address, apiKey
+      });
+      return getRequest(query);
+    },
+    /**
+     * Get a list of internal transactions
+     * @param {string} txhash - Transaction hash. If specified then address will be ignored
+     * @param {string} address - Transaction address
+     * @param {string} startblock - start looking here
+     * @param {string} endblock - end looking there
+     * @param {string} sort - Sort asc/desc
+     * @example
+     * var txlist = api.account.txlistinternal('0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170');
+     * @returns {Promise.<object>}
+     */
+    txlistinternal(txhash, address, startblock, endblock, sort) {
+      const module = 'account';
+      const action = 'txlistinternal';
+
+      var queryObject = {
+        module,
+        action,
+        apiKey
+      };
+
+      if (!startblock) {
+        startblock = 0;
+      }
+
+      if (!endblock) {
+        endblock = 'latest';
+      }
+
+      if (!sort) {
+        sort = 'asc';
+      }
+
+      if (txhash) {
+        queryObject.txhash = txhash;
+      } else {
+        queryObject.address = address;
+      }
+
+      queryObject.txhash = txhash;
+
+      return getRequest(querystring.stringify(queryObject));
+    },
+    /**
+     * Get a list of transactions for a specfic address
+     * @param {string} address - Transaction address
+     * @param {string} startblock - start looking here
+     * @param {string} endblock - end looking there
+     * @param {string} sort - Sort asc/desc
+     * @example
+     * var txlist = api.account.txlist('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', 1, 'latest', 'asc');
+     * @returns {Promise.<object>}
+     */
+    txlist(address, startblock, endblock, sort) {
+      const module = 'account';
+      const action = 'txlist';
+
+      if (!startblock) {
+        startblock = 0;
+      }
+
+      if (!endblock) {
+        endblock = 'latest';
+      }
+
+      if (!sort) {
+        sort = 'asc';
+      }
+
+      var query = querystring.stringify({
+        module, action, startblock, endblock, sort, address, apiKey
+      });
+
+      return getRequest(query);
+    },
+    /**
+     * Get a list of blocks that a specific account has mineds
+     * @example
+     * var txlist = api.account.getminedblocks('0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b');
+     * @param {string} address - Transaction hash
+     */
+    getminedblocks(address) {
+      const module = 'account';
+      const action = 'getminedblocks';
+      var query = querystring.stringify({
+        module, action, address, apiKey
+      });
+      return getRequest(query);
+    },
+     /**
+     * [BETA] Get a list of "ERC20 - Token Transfer Events" by Address
+     * @param {string} address - Account address
+     * @param {string} startblock - start looking here
+     * @param {string} endblock - end looking there
+     * @param {string} sort - Sort asc/desc
+     * @param {string} contractaddress - Address of ERC20 token contract (if not specified lists transfers for all tokens)
+     * @example
+     * var txlist = api.account.tokentx('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', '0x5F988D968cb76c34C87e6924Cc1Ef1dCd4dE75da', 1, 'latest', 'asc');
+     * @returns {Promise.<object>}
+     */
+    tokentx(address, contractaddress, startblock, endblock, sort) {
+      const module = 'account';
+      const action = 'tokentx';
+
+      if (!startblock) {
+        startblock = 0;
+      }
+
+      if (!endblock) {
+        endblock = 'latest';
+      }
+
+      if (!sort) {
+        sort = 'asc';
+      }
+
+      var queryObject = {
+        module, action, startblock, endblock, sort, address, apiKey
+      };
+
+      if (contractaddress) {
+        queryObject.contractaddress = contractaddress;
+      }
+
+      return getRequest(querystring.stringify(queryObject));
+    }
+  };
 };
 
+},{"querystring":40}],3:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * Find the block reward for a given address and block
+     * @param {string} address - Address of the block
+     * @param {string} blockno - Block number
+     * @returns {Promise.<object>}
+     */
+    getblockreward(address, blockno) {
+      const module = 'block';
+      const action = 'getblockreward';
+      if (!blockno) {
+        blockno = 0;
+      }
+      var query = querystring.stringify({
+        module, action, address, blockno, apiKey
+      });
+      return getRequest(query);
+    }
+  };
+};
+
+},{"querystring":40}],4:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * Returns the ABI/Interface of a given contract
+     * @param {string} address - Contract address
+     * @example
+     * api.contract
+     *  .getabi('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
+     *  .at('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
+     *  .memberId('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
+     *  .then(console.log)
+     * @returns {Promise.<object>}
+     */
+    getabi(address) {
+      const module = 'contract';
+      const action = 'getabi';
+
+      var query = querystring.stringify({
+        module, action, address, apiKey
+      });
+
+      return getRequest(query);
+    }
+  };
+};
+
+},{"querystring":40}],5:[function(require,module,exports){
+
+const axios = require('axios');
+/**
+ * @param {string} chain
+ * @returns {string}
+ */
+function pickChainUrl(chain) {
+  if (!chain || !TESTNET_API_URL_MAP[chain]) {
+    return MAIN_API_URL;
+  }
+
+  return TESTNET_API_URL_MAP[chain];
+}
+
+
+const MAIN_API_URL = 'https://api.etherscan.io';
+const TESTNET_API_URL_MAP = {
+  ropsten: 'http://api-ropsten.etherscan.io',
+  kovan: 'http://api-kovan.etherscan.io',
+  rinkeby: 'https://api-rinkeby.etherscan.io',
+  homestead: 'https://api.etherscan.io'
+};
+
+module.exports = function(chain, timeout) {
+  var client = axios.create({
+    baseURL: pickChainUrl(chain),
+    timeout: timeout
+  });
+
+  /**
+   * @param query
+   * @returns {Promise<any>}
+   */
+  function getRequest(query) {
+    return new Promise(function(resolve, reject) {
+      client.get('/api?' + query).then(function(response) {
+        var data = response.data;
+
+        if (data.status && data.status != 1) {
+          return reject(data.message);
+        }
+
+        if (data.error) {
+          return reject(new Error(data.error));
+        }
+        resolve(data);
+      }).catch(function(error) {
+        return reject(new Error(error));
+      });
+    });
+  }
+
+  return getRequest;
+};
+
+},{"axios":11}],6:[function(require,module,exports){
+"use strict";
+const log = require('./log');
+const proxy = require('./proxy');
+const stats = require('./stats');
+const block = require('./block');
+const transaction = require('./transaction');
+const contract = require('./contract');
+const account = require('./account');
 /**
  * @module etherscan/api
  */
 
-// chain is for testnet (ropsten, rinkeby, kovan)
-module.exports = function (apiKey, chain) {
+/**
+ * @param {string} apiKey - (optional) Your Etherscan APIkey
+ * @param {string} chain - (optional) Testnet chain keys [ropsten, rinkeby, kovan]
+ * @param {number} timeout - (optional) Timeout in milliseconds for requests, default 10000
+ */
+module.exports = function(apiKey, chain, timeout) {
 
   if (!apiKey) {
     apiKey = 'YourApiKeyToken';
   }
 
-  function pickChainUrl(chain) {
-    if (!chain) {
-      return url;
-    }
 
-    if (!testUrls[chain]) {
-      throw Error('Chain missing ' + chain);
-    }
-
-    return testUrls[chain];
+  if (!timeout) {
+    timeout = 10000;
   }
 
-  var client = axios.create({
-    baseURL: pickChainUrl(chain),
-    timeout: 3000
-  });
-
-  function getRequest(query) {
-    return new Promise(function (resolve, reject) {
-      client.get('/api?' + query)
-        .then(function (response) {
-          var data = response.data;
-
-          if (data.status && data.status != 1) {
-            return reject(data.message);
-          }
-
-          if (data.error) {
-            return reject(data.error.message);
-          }
-
-          resolve(data);
-        })
-        .catch(function (error) {
-          return reject(error);
-        });
-    });
-  }
+  var getRequest = require('./get-request')(chain, timeout);
 
   /** @lends module:etherscan/api */
   return {
     /**
      * @namespace
      */
-    log: {
-      /**
-       * The Event Log API was designed to provide an alternative to the native eth_getLogs.
-       */
-      getLogs(address,
-              fromBlock,
-              toBlock,
-              topic0,
-              topic0_1_opr,
-              topic1,
-              topic1_2_opr,
-              topic2,
-              topic2_3_opr,
-              topic3) {
-
-        const module = 'logs';
-        const action = 'getLogs';
-        var params = {
-          module, action, apiKey, address
-        };
-
-        if (address) {
-          params.address = address;
-        }
-
-        if (fromBlock) {
-          params.fromBlock = fromBlock;
-        }
-
-        if (toBlock) {
-          params.toBlock = toBlock;
-        }
-
-        if (topic0) {
-          params.topic0 = topic0;
-        }
-
-        if (topic0_1_opr) {
-          params.topic0_1_opr = topic0_1_opr;
-        }
-
-        if (topic1) {
-          params.topic1 = topic1;
-        }
-
-        if (topic1_2_opr) {
-          params.topic1_2_opr = topic1_2_opr;
-        }
-
-        if (topic2) {
-          params.topic2 = topic2;
-        }
-
-        if (topic2_3_opr) {
-          params.topic2_3_opr = topic2_3_opr;
-        }
-
-        if (topic3) {
-          params.topic3 = topic3;
-        }
-        var query = querystring.stringify(params);
-        return getRequest(query);
-      }
-    },
+    log: log(getRequest, apiKey),
     /**
      * @namespace
      */
-    proxy: {
-      /**
-       * Returns the number of most recent block
-       * @example
-       * var block = api.proxy.eth_blockNumber();
-       * @returns {Promise.<integer>}
-       */
-      eth_blockNumber() {
-        const module = 'proxy';
-        const action = 'eth_blockNumber';
-        var query = querystring.stringify({
-          module, action, apiKey
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns information about a block by block number.
-       * @param {string} tag - Tag to look up
-       * @example
-       * var blockNumber = api.proxy.eth_getBlockByNumber('0x10d4f');
-       * @returns {Promise.<integer>}
-       */
-      eth_getBlockByNumber(tag) {
-        const module = 'proxy';
-        const action = 'eth_getBlockByNumber';
-        const boolean = true;
-        var query = querystring.stringify({
-          module, action, tag, apiKey, boolean
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns information about a uncle by block number.
-       * @param {string} tag - Tag to look up
-       * @param {string} index - Index
-       * @example
-       * var res = api.proxy.eth_getUncleByBlockNumberAndIndex('0x210A9B', '0x0');
-       * @returns {Promise.<object>}
-       */
-      eth_getUncleByBlockNumberAndIndex(tag, index) {
-        const module = 'proxy';
-        const action = 'eth_getUncleByBlockNumberAndIndex';
-        var query = querystring.stringify({
-          module, action, apiKey, tag, index
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the number of transactions in a block from a block matching the given block number
-       * @param {string} tag - Tag to look up
-       * @example
-       * var res = api.proxy.eth_getBlockTransactionCountByNumber('0x10FB78');
-       * @returns {Promise.<object>}
-       */
-      eth_getBlockTransactionCountByNumber(tag) {
-        const module = 'proxy';
-        const action = 'eth_getBlockTransactionCountByNumber';
-        var query = querystring.stringify({
-          module, action, apiKey, tag
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the information about a transaction requested by transaction hash
-       * @param {string} hash - Transaction hash
-       * @example
-       * var res = api.proxy.eth_getTransactionByHash('0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1');
-       * @returns {Promise.<object>}
-       */
-      eth_getTransactionByHash(txhash) {
-        const module = 'proxy';
-        const action = 'eth_getTransactionByHash';
-        var query = querystring.stringify({
-          module, action, apiKey, txhash
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns information about a transaction by block number and transaction index position
-       * @param {string} tag - Tag to look up
-       * @param {string} index - Index
-       * @example
-       * var res = api.proxy.eth_getTransactionByBlockNumberAndIndex('0x10d4f', '0x0');
-       * @returns {Promise.<object>}
-       */
-      eth_getTransactionByBlockNumberAndIndex(tag, index) {
-        const module = 'proxy';
-        const action = 'eth_getTransactionByBlockNumberAndIndex';
-        var query = querystring.stringify({
-          module, action, apiKey, tag, index
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the number of transactions sent from an address
-       * @param {string} address - Address of the transaction
-       * @example
-       * var res = api.proxy.eth_getTransactionCount('0x2910543af39aba0cd09dbb2d50200b3e800a63d2', 'latest');
-       * @returns {Promise.<object>}
-       */
-      eth_getTransactionCount(address) {
-        const module = 'proxy';
-        const action = 'eth_getTransactionCount';
-        var query = querystring.stringify({
-          module, action, apiKey, address
-        });
-        return getRequest(query);
-      },
-      /**
-       * Creates new message call transaction or a contract creation for signed transactions
-       * @param {string} hex - Serialized Message
-       * @example
-       * var res = api.proxy.eth_sendRawTransaction('0xf904808000831cfde080');
-       * @returns {Promise.<object>}
-       */
-      eth_sendRawTransaction(hex) {
-        const module = 'proxy';
-        const action = 'eth_sendRawTransaction';
-        var query = querystring.stringify({
-          module, action, apiKey, hex
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the receipt of a transaction by transaction hash
-       * @param {string} txhash - Transaction hash
-       * @example
-       * var ret = api.proxy.eth_getTransactionReceipt('0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1');
-       * @returns {Promise.<object>}
-       */
-      eth_getTransactionReceipt(txhash) {
-        const module = 'proxy';
-        const action = 'eth_getTransactionReceipt';
-        var query = querystring.stringify({
-          module, action, apiKey, txhash
-        });
-        return getRequest(query);
-      },
-      /**
-       * Executes a new message call immediately without creating a transaction on the block chain
-       * @param {string} to - Address to execute from
-       * @param {string} data - Data to transfer
-       * @param {string} tag - A tag
-       * @example
-       * var res = api.proxy.eth_call('0xAEEF46DB4855E25702F8237E8f403FddcaF931C0', '0x70a08231000000000000000000000000e16359506c028e51f16be38986ec5746251e9724', 'latest');
-       * @returns {Promise.<object>}
-       */
-      eth_call(to, data, tag) {
-        const module = 'proxy';
-        const action = 'eth_call';
-        var query = querystring.stringify({
-          module, action, apiKey, to, data, tag
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns code at a given address
-       * @param {string} address - Address to get code from
-       * @param {string} tag - ??
-       * @example
-       * var res = api.proxy.eth_getCode('0xf75e354c5edc8efed9b59ee9f67a80845ade7d0c',  'latest');
-       * @returns {Promise.<object>}
-       */
-      eth_getCode(address, tag) {
-        const module = 'proxy';
-        const action = 'eth_getCode';
-        var query = querystring.stringify({
-          module, action, apiKey, address, tag
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the value from a storage position at a given address.
-       * @param {string} address - Address to get code from
-       * @param {string} position - Storage position
-       * @param {string} tag - ??
-       * @example
-       * var res = api.proxy.eth_getStorageAt('0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd', '0x0',  'latest');
-       * @returns {Promise.<object>}
-       */
-      eth_getStorageAt(address, position, tag) {
-        const module = 'proxy';
-        const action = 'eth_getStorageAt';
-        var query = querystring.stringify({
-          module, action, apiKey, address, position, tag
-        });
-        return getRequest(query);
-      },
-      /**
-       * Returns the current price per gas in wei.
-       * var gasprice = api.proxy.eth_gasPrice();
-       * @returns {Promise.<object>}
-       */
-      eth_gasPrice() {
-        const module = 'proxy';
-        const action = 'eth_gasPrice';
-        var query = querystring.stringify({
-          module, action, apiKey
-        });
-        return getRequest(query);
-      },
-      /**
-       * Makes a call or transaction, which won't be added to the blockchain and returns the used gas, which can be used for estimating the used gas
-       * @param {string} to - Address to get code from
-       * @param {string} value - Storage position
-       * @param {string} gasPrice - ??
-       * @param {string} gas - ??
-       * @xample
-       * var res = api.proxy.eth_estimateGas(
-       *  '0xf0160428a8552ac9bb7e050d90eeade4ddd52843',
-       *  '0xff22',
-       *  '0x051da038cc',
-       *  '0xffffff'
-       *);
-       * @returns {Promise.<object>}
-       */
-      eth_estimateGas(to, value, gasPrice, gas) {
-        const module = 'proxy';
-        const action = 'eth_estimateGas';
-        var query = querystring.stringify({
-          module, action, apiKey, to, value, gasPrice, gas
-        });
-        return getRequest(query);
-      },
-    },
+    proxy: proxy(getRequest, apiKey),
     /**
      * @namespace
      */
-    stats: {
-      /**
-       * Returns the supply of Tokens
-       * @param {string} tokenname - Name of the Token
-       * @param {string} contractaddress - Address from token contract
-       * @example
-       * var supply = api.stats.tokensupply(null, '0x57d90b64a1a57749b0f932f1a3395792e12e7055');
-       * @returns {Promise.<object>}
-       */
-      tokensupply(tokenname, contractaddress) {
-        const module = 'stats';
-        const action = 'tokensupply';
-
-        let params = {
-          module, action, apiKey
-        };
-
-        if (tokenname) {
-          params.tokenname = tokenname;
-        }
-
-        if (contractaddress) {
-          params.contractaddress = contractaddress;
-        }
-
-        var query = querystring.stringify(params);
-        return getRequest(query);
-      },
-
-      /**
-       * Returns total supply of ether
-       * var supply = api.stats.ethsupply();
-       * @returns {Promise.<integer>}
-       */
-      ethsupply() {
-        const module = 'stats';
-        const action = 'ethsupply';
-        var query = querystring.stringify({
-          module, action, apiKey
-        });
-        return getRequest(query);
-      },
-
-      /**
-       * Returns the price of ether now
-       * @example
-       * var price = api.stats.ethprice();
-       * @returns {Promise.<integer>}
-       */
-      ethprice() {
-        const module = 'stats';
-        const action = 'ethprice';
-        var query = querystring.stringify({
-          module, action, apiKey
-        });
-        return getRequest(query);
-      }
-    },
+    stats: stats(getRequest, apiKey),
     /**
      * @namespace
      */
-    block: {
-      /**
-       * Find the block reward for a given address and block
-       * @param {string} address - Address of the block
-       * @param {string} blockno - Block number
-       * @returns {Promise.<object>}
-       */
-      getblockreward(address, blockno) {
-        const module = 'block';
-        const action = 'getblockreward';
-        if (!blockno) {
-          blockno = 0;
-        }
-        var query = querystring.stringify({
-          module, action, address, blockno, apiKey
-        });
-        return getRequest(query);
-      }
-    },
+    block: block(getRequest, apiKey),
     /**
      * @namespace
      */
-    transaction: {
-      /**
-       * returns the status of a specific transaction hash
-       * @param {string} txhash - Transaction hash
-       * @returns {Promise.<object>}
-       */
-      getstatus(txhash) {
-        const module = 'transaction';
-        const action = 'getstatus';
-        var query = querystring.stringify({
-          module, action, txhash, apiKey
-        });
-        return getRequest(query);
-      }
-    },
+    transaction: transaction(getRequest, apiKey),
     /**
      * @namespace
      */
-    contract: {
-      /**
-       * Returns the ABI/Interface of a given contract
-       * @param {string} address - Contract address
-       * @example
-       * api.contract
-       *  .getabi('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
-       *  .at('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
-       *  .memberId('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359')
-       *  .then(console.log)
-       * @returns {Promise.<object>}
-       */
-      getabi(address) {
-        const module = 'contract';
-        const action = 'getabi';
-
-        var query = querystring.stringify({
-          module, action, address, apiKey
-        });
-
-        return getRequest(query);
-      }
-    },
+    contract: contract(getRequest, apiKey),
     /**
      * @namespace
      */
-    account: {
-      /**
-       * Returns the amount of Tokens a specific account owns.
-       * @param {string} address - Contract address
-       * @param {string} tokenname - Name of the token
-       * @param {string} contractaddress - Contract address
-       * @example
-       *     var supply = api.account.tokenbalance(
-       *       '0x4366ddc115d8cf213c564da36e64c8ebaa30cdbd',
-       *       'DGD',
-       *       ''
-       * );
-       * @returns {Promise.<object>}
-       */
-      tokenbalance(address, tokenname, contractaddress) {
+    account: account(getRequest, apiKey)
+  };
+};
 
-        const module = 'account';
-        const action = 'tokenbalance';
-        const tag = 'latest';
+},{"./account":2,"./block":3,"./contract":4,"./get-request":5,"./log":7,"./proxy":8,"./stats":9,"./transaction":10}],7:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * The Event Log API was designed to provide an alternative to the native eth_getLogs.
+     */
+     /**
+      * returns the status of a specific transaction hash
+      * @param {string} fromBlock - fromBlock
+      * @param {string} toBlock - toBlock
+      * @param {string} topic0 - topic (32 Bytes per topic)
+      * @param {string} topic0_1_opr - and|or between topic0 & topic1
+      * @param {string} topic1 - topic (32 Bytes per topic)
+      * @param {string} topic1_2_opr - and|or between topic1 & topic2
+      * @param {string} topic2 - topic (32 Bytes per topic)
+      * @param {string} topic2_3_opr - and|or between topic2 & topic3
+      * @param {string} topic3 - topic (32 Bytes per topic)
+      * @param {string} topic0_2_opr - and|or between topic0 & topic2
+      * @example https://etherscan.io/apis#logs
+      * @returns {Promise.<object>}
+      */
+    getLogs(address,
+            fromBlock,
+            toBlock,
+            topic0,
+            topic0_1_opr,
+            topic1,
+            topic1_2_opr,
+            topic2,
+            topic2_3_opr,
+            topic3,
+            topic0_2_opr) {
 
-        var queryObject = {
-          module, action, apiKey, tag
-        };
+      const module = 'logs';
+      const action = 'getLogs';
+      var params = {
+        module, action, apiKey, address
+      };
 
-        if (contractaddress) {
-          queryObject.contractaddress = contractaddress;
-        }
-
-        if (tokenname) {
-          queryObject.tokenname = tokenname;
-        }
-
-        if (address) {
-          queryObject.address = address;
-        }
-
-        var query = querystring.stringify(queryObject);
-
-        return getRequest(query);
-      },
-      /**
-       * Returns the balance of a sepcific account
-       * @param {string} address - Address
-       * @example
-       * var balance = api.account.balance('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae');
-       * @returns {Promise.<object>}
-       */
-      balance(address) {
-        const module = 'account';
-        let action = 'balance';
-        const tag = 'latest';
-
-        if (typeof address != 'string' && address.length) {
-          address = address.join(',');
-          action = 'balancemulti';
-        }
-
-        var query = querystring.stringify({
-          module, action, tag, address, apiKey
-        });
-        return getRequest(query);
-      },
-      /**
-       * Get a list of internal transactions
-       * @param {string} txhash - Transaction hash. If specified then address will be ignored
-       * @param {string} address - Transaction address
-       * @param {string} startblock - start looking here
-       * @param {string} endblock - end looking there
-       * @param {string} sort - Sort asc/desc
-       * @example
-       * var txlist = api.account.txlistinternal('0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170');
-       * @returns {Promise.<object>}
-       */
-      txlistinternal(txhash, address, startblock, endblock, sort) {
-        const module = 'account';
-        const action = 'txlistinternal';
-
-        var queryParams = {
-          module,
-          action,
-          apiKey
-        };
-
-        if (!startblock) {
-          startblock = 0;
-        }
-
-        if (!endblock) {
-          endblock = 'latest';
-        }
-
-        if (!sort) {
-          sort = 'asc';
-        }
-
-        if (txhash) {
-          queryParams.txhash = txhash;
-        } else {
-          queryParams.address = address;
-        }
-
-        queryParams.txhash = txhash;
-
-        return getRequest(querystring.stringify(queryParams));
-      },
-      /**
-       * Get a list of transactions for a specfic address
-       * @param {string} address - Transaction address
-       * @param {string} startblock - start looking here
-       * @param {string} endblock - end looking there
-       * @param {string} sort - Sort asc/desc
-       * @example
-       * var txlist = api.account.txlist('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', 1, 'latest', 'asc');
-       * @returns {Promise.<object>}
-       */
-      txlist(address, startblock, endblock, sort) {
-        const module = 'account';
-        const action = 'txlist';
-
-        if (!startblock) {
-          startblock = 0;
-        }
-
-        if (!endblock) {
-          endblock = 'latest';
-        }
-
-        if (!sort) {
-          sort = 'asc';
-        }
-
-        var query = querystring.stringify({
-          module, action, startblock, endblock, sort, address, apiKey
-        });
-
-        return getRequest(query);
-      },
-      /**
-       * Get a list of blocks that a specific account has mineds
-       * @example
-       * var txlist = api.account.getminedblocks('0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b');
-       * @param {string} address - Transaction hash
-       */
-      getminedblocks(address) {
-        const module = 'account';
-        const action = 'getminedblocks';
-        var query = querystring.stringify({
-          module, action, address, apiKey
-        });
-        return getRequest(query);
+      if (address) {
+        params.address = address;
       }
+
+      if (fromBlock) {
+        params.fromBlock = fromBlock;
+      }
+
+      if (toBlock) {
+        params.toBlock = toBlock;
+      }
+
+      if (topic0) {
+        params.topic0 = topic0;
+      }
+
+      if (topic0_1_opr) {
+        params.topic0_1_opr = topic0_1_opr;
+      }
+
+      if (topic1) {
+        params.topic1 = topic1;
+      }
+
+      if (topic1_2_opr) {
+        params.topic1_2_opr = topic1_2_opr;
+      }
+
+      if (topic2) {
+        params.topic2 = topic2;
+      }
+
+      if (topic2_3_opr) {
+        params.topic2_3_opr = topic2_3_opr;
+      }
+
+      if (topic0_2_opr) {
+        params.topic0_2_opr = topic0_2_opr;
+      }
+
+      if (topic3) {
+        params.topic3 = topic3;
+      }
+      var query = querystring.stringify(params);
+      return getRequest(query);
     }
   };
 };
 
-},{"axios":3,"querystring":32}],3:[function(require,module,exports){
+},{"querystring":40}],8:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports =function(getRequest, apiKey) {
+  return {
+    /**
+     * Returns the number of most recent block
+     * @example
+     * var block = api.proxy.eth_blockNumber();
+     * @returns {Promise.<integer>}
+     */
+    eth_blockNumber() {
+      const module = 'proxy';
+      const action = 'eth_blockNumber';
+      var query = querystring.stringify({
+        module, action, apiKey
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns information about a block by block number.
+     * @param {string} tag - Tag to look up
+     * @example
+     * var blockNumber = api.proxy.eth_getBlockByNumber('0x10d4f');
+     * @returns {Promise.<integer>}
+     */
+    eth_getBlockByNumber(tag) {
+      const module = 'proxy';
+      const action = 'eth_getBlockByNumber';
+      const boolean = true;
+      var query = querystring.stringify({
+        module, action, tag, apiKey, boolean
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns information about a uncle by block number.
+     * @param {string} tag - Tag to look up
+     * @param {string} index - Index
+     * @example
+     * var res = api.proxy.eth_getUncleByBlockNumberAndIndex('0x210A9B', '0x0');
+     * @returns {Promise.<object>}
+     */
+    eth_getUncleByBlockNumberAndIndex(tag, index) {
+      const module = 'proxy';
+      const action = 'eth_getUncleByBlockNumberAndIndex';
+      var query = querystring.stringify({
+        module, action, apiKey, tag, index
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the number of transactions in a block from a block matching the given block number
+     * @param {string} tag - Tag to look up
+     * @example
+     * var res = api.proxy.eth_getBlockTransactionCountByNumber('0x10FB78');
+     * @returns {Promise.<object>}
+     */
+    eth_getBlockTransactionCountByNumber(tag) {
+      const module = 'proxy';
+      const action = 'eth_getBlockTransactionCountByNumber';
+      var query = querystring.stringify({
+        module, action, apiKey, tag
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the information about a transaction requested by transaction hash
+     * @param {string} hash - Transaction hash
+     * @example
+     * var res = api.proxy.eth_getTransactionByHash('0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1');
+     * @returns {Promise.<object>}
+     */
+    eth_getTransactionByHash(txhash) {
+      const module = 'proxy';
+      const action = 'eth_getTransactionByHash';
+      var query = querystring.stringify({
+        module, action, apiKey, txhash
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns information about a transaction by block number and transaction index position
+     * @param {string} tag - Tag to look up
+     * @param {string} index - Index
+     * @example
+     * var res = api.proxy.eth_getTransactionByBlockNumberAndIndex('0x10d4f', '0x0');
+     * @returns {Promise.<object>}
+     */
+    eth_getTransactionByBlockNumberAndIndex(tag, index) {
+      const module = 'proxy';
+      const action = 'eth_getTransactionByBlockNumberAndIndex';
+      var query = querystring.stringify({
+        module, action, apiKey, tag, index
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the number of transactions sent from an address
+     * @param {string} address - Address of the transaction
+     * @example
+     * var res = api.proxy.eth_getTransactionCount('0x2910543af39aba0cd09dbb2d50200b3e800a63d2', 'latest');
+     * @returns {Promise.<object>}
+     */
+    eth_getTransactionCount(address) {
+      const module = 'proxy';
+      const action = 'eth_getTransactionCount';
+      var query = querystring.stringify({
+        module, action, apiKey, address
+      });
+      return getRequest(query);
+    },
+    /**
+     * Creates new message call transaction or a contract creation for signed transactions
+     * @param {string} hex - Serialized Message
+     * @example
+     * var res = api.proxy.eth_sendRawTransaction('0xf904808000831cfde080');
+     * @returns {Promise.<object>}
+     */
+    eth_sendRawTransaction(hex) {
+      const module = 'proxy';
+      const action = 'eth_sendRawTransaction';
+      var query = querystring.stringify({
+        module, action, apiKey, hex
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the receipt of a transaction by transaction hash
+     * @param {string} txhash - Transaction hash
+     * @example
+     * var ret = api.proxy.eth_getTransactionReceipt('0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1');
+     * @returns {Promise.<object>}
+     */
+    eth_getTransactionReceipt(txhash) {
+      const module = 'proxy';
+      const action = 'eth_getTransactionReceipt';
+      var query = querystring.stringify({
+        module, action, apiKey, txhash
+      });
+      return getRequest(query);
+    },
+    /**
+     * Executes a new message call immediately without creating a transaction on the block chain
+     * @param {string} to - Address to execute from
+     * @param {string} data - Data to transfer
+     * @param {string} tag - A tag
+     * @example
+     * var res = api.proxy.eth_call('0xAEEF46DB4855E25702F8237E8f403FddcaF931C0', '0x70a08231000000000000000000000000e16359506c028e51f16be38986ec5746251e9724', 'latest');
+     * @returns {Promise.<object>}
+     */
+    eth_call(to, data, tag) {
+      const module = 'proxy';
+      const action = 'eth_call';
+      var query = querystring.stringify({
+        module, action, apiKey, to, data, tag
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns code at a given address
+     * @param {string} address - Address to get code from
+     * @param {string} tag - ??
+     * @example
+     * var res = api.proxy.eth_getCode('0xf75e354c5edc8efed9b59ee9f67a80845ade7d0c',  'latest');
+     * @returns {Promise.<object>}
+     */
+    eth_getCode(address, tag) {
+      const module = 'proxy';
+      const action = 'eth_getCode';
+      var query = querystring.stringify({
+        module, action, apiKey, address, tag
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the value from a storage position at a given address.
+     * @param {string} address - Address to get code from
+     * @param {string} position - Storage position
+     * @param {string} tag - ??
+     * @example
+     * var res = api.proxy.eth_getStorageAt('0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd', '0x0',  'latest');
+     * @returns {Promise.<object>}
+     */
+    eth_getStorageAt(address, position, tag) {
+      const module = 'proxy';
+      const action = 'eth_getStorageAt';
+      var query = querystring.stringify({
+        module, action, apiKey, address, position, tag
+      });
+      return getRequest(query);
+    },
+    /**
+     * Returns the current price per gas in wei.
+     * var gasprice = api.proxy.eth_gasPrice();
+     * @returns {Promise.<object>}
+     */
+    eth_gasPrice() {
+      const module = 'proxy';
+      const action = 'eth_gasPrice';
+      var query = querystring.stringify({
+        module, action, apiKey
+      });
+      return getRequest(query);
+    },
+    /**
+     * Makes a call or transaction, which won't be added to the blockchain and returns the used gas, which can be used for estimating the used gas
+     * @param {string} to - Address to get code from
+     * @param {string} value - Storage position
+     * @param {string} gasPrice - ??
+     * @param {string} gas - ??
+     * @xample
+     * var res = api.proxy.eth_estimateGas(
+     *  '0xf0160428a8552ac9bb7e050d90eeade4ddd52843',
+     *  '0xff22',
+     *  '0x051da038cc',
+     *  '0xffffff'
+     *);
+     * @returns {Promise.<object>}
+     */
+    eth_estimateGas(to, value, gasPrice, gas) {
+      const module = 'proxy';
+      const action = 'eth_estimateGas';
+      var query = querystring.stringify({
+        module, action, apiKey, to, value, gasPrice, gas
+      });
+      return getRequest(query);
+    },
+  };
+};
+
+},{"querystring":40}],9:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * Returns the supply of Tokens
+     * @param {string} tokenname - Name of the Token
+     * @param {string} contractaddress - Address from token contract
+     * @example
+     * var supply = api.stats.tokensupply(null, '0x57d90b64a1a57749b0f932f1a3395792e12e7055');
+     * @returns {Promise.<object>}
+     */
+    tokensupply(tokenname, contractaddress) {
+      const module = 'stats';
+      const action = 'tokensupply';
+
+      let params = {
+        module, action, apiKey
+      };
+
+      if (tokenname) {
+        params.tokenname = tokenname;
+      }
+
+      if (contractaddress) {
+        params.contractaddress = contractaddress;
+      }
+
+      var query = querystring.stringify(params);
+      return getRequest(query);
+    },
+
+    /**
+     * Returns total supply of ether
+     * var supply = api.stats.ethsupply();
+     * @returns {Promise.<integer>}
+     */
+    ethsupply() {
+      const module = 'stats';
+      const action = 'ethsupply';
+      var query = querystring.stringify({
+        module, action, apiKey
+      });
+      return getRequest(query);
+    },
+
+    /**
+     * Returns the price of ether now
+     * @example
+     * var price = api.stats.ethprice();
+     * @returns {Promise.<integer>}
+     */
+    ethprice() {
+      const module = 'stats';
+      const action = 'ethprice';
+      var query = querystring.stringify({
+        module, action, apiKey
+      });
+      return getRequest(query);
+    }
+  };
+};
+
+},{"querystring":40}],10:[function(require,module,exports){
+const querystring = require('querystring');
+module.exports = function(getRequest, apiKey) {
+  return {
+    /**
+     * returns the status of a specific transaction hash
+     * @param {string} txhash - Transaction hash
+     * @returns {Promise.<object>}
+     */
+    getstatus(txhash) {
+      const module = 'transaction';
+      const action = 'getstatus';
+      var query = querystring.stringify({
+        module, action, txhash, apiKey
+      });
+      return getRequest(query);
+    }
+  };
+};
+
+},{"querystring":40}],11:[function(require,module,exports){
 module.exports = require('./lib/axios');
-},{"./lib/axios":5}],4:[function(require,module,exports){
+},{"./lib/axios":13}],12:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -837,7 +959,7 @@ module.exports = function xhrAdapter(config) {
 };
 
 }).call(this,require('_process'))
-},{"../core/createError":11,"./../core/settle":14,"./../helpers/btoa":18,"./../helpers/buildURL":19,"./../helpers/cookies":21,"./../helpers/isURLSameOrigin":23,"./../helpers/parseHeaders":25,"./../utils":27,"_process":29}],5:[function(require,module,exports){
+},{"../core/createError":19,"./../core/settle":22,"./../helpers/btoa":26,"./../helpers/buildURL":27,"./../helpers/cookies":29,"./../helpers/isURLSameOrigin":31,"./../helpers/parseHeaders":33,"./../utils":35,"_process":37}],13:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -891,7 +1013,7 @@ module.exports = axios;
 // Allow use of default import syntax in TypeScript
 module.exports.default = axios;
 
-},{"./cancel/Cancel":6,"./cancel/CancelToken":7,"./cancel/isCancel":8,"./core/Axios":9,"./defaults":16,"./helpers/bind":17,"./helpers/spread":26,"./utils":27}],6:[function(require,module,exports){
+},{"./cancel/Cancel":14,"./cancel/CancelToken":15,"./cancel/isCancel":16,"./core/Axios":17,"./defaults":24,"./helpers/bind":25,"./helpers/spread":34,"./utils":35}],14:[function(require,module,exports){
 'use strict';
 
 /**
@@ -912,7 +1034,7 @@ Cancel.prototype.__CANCEL__ = true;
 
 module.exports = Cancel;
 
-},{}],7:[function(require,module,exports){
+},{}],15:[function(require,module,exports){
 'use strict';
 
 var Cancel = require('./Cancel');
@@ -971,14 +1093,14 @@ CancelToken.source = function source() {
 
 module.exports = CancelToken;
 
-},{"./Cancel":6}],8:[function(require,module,exports){
+},{"./Cancel":14}],16:[function(require,module,exports){
 'use strict';
 
 module.exports = function isCancel(value) {
   return !!(value && value.__CANCEL__);
 };
 
-},{}],9:[function(require,module,exports){
+},{}],17:[function(require,module,exports){
 'use strict';
 
 var defaults = require('./../defaults');
@@ -1059,7 +1181,7 @@ utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
 
 module.exports = Axios;
 
-},{"./../defaults":16,"./../utils":27,"./InterceptorManager":10,"./dispatchRequest":12}],10:[function(require,module,exports){
+},{"./../defaults":24,"./../utils":35,"./InterceptorManager":18,"./dispatchRequest":20}],18:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1113,7 +1235,7 @@ InterceptorManager.prototype.forEach = function forEach(fn) {
 
 module.exports = InterceptorManager;
 
-},{"./../utils":27}],11:[function(require,module,exports){
+},{"./../utils":35}],19:[function(require,module,exports){
 'use strict';
 
 var enhanceError = require('./enhanceError');
@@ -1133,7 +1255,7 @@ module.exports = function createError(message, config, code, request, response) 
   return enhanceError(error, config, code, request, response);
 };
 
-},{"./enhanceError":13}],12:[function(require,module,exports){
+},{"./enhanceError":21}],20:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1221,7 +1343,7 @@ module.exports = function dispatchRequest(config) {
   });
 };
 
-},{"../cancel/isCancel":8,"../defaults":16,"./../helpers/combineURLs":20,"./../helpers/isAbsoluteURL":22,"./../utils":27,"./transformData":15}],13:[function(require,module,exports){
+},{"../cancel/isCancel":16,"../defaults":24,"./../helpers/combineURLs":28,"./../helpers/isAbsoluteURL":30,"./../utils":35,"./transformData":23}],21:[function(require,module,exports){
 'use strict';
 
 /**
@@ -1244,7 +1366,7 @@ module.exports = function enhanceError(error, config, code, request, response) {
   return error;
 };
 
-},{}],14:[function(require,module,exports){
+},{}],22:[function(require,module,exports){
 'use strict';
 
 var createError = require('./createError');
@@ -1272,7 +1394,7 @@ module.exports = function settle(resolve, reject, response) {
   }
 };
 
-},{"./createError":11}],15:[function(require,module,exports){
+},{"./createError":19}],23:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1294,7 +1416,7 @@ module.exports = function transformData(data, headers, fns) {
   return data;
 };
 
-},{"./../utils":27}],16:[function(require,module,exports){
+},{"./../utils":35}],24:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -1390,7 +1512,7 @@ utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
 module.exports = defaults;
 
 }).call(this,require('_process'))
-},{"./adapters/http":4,"./adapters/xhr":4,"./helpers/normalizeHeaderName":24,"./utils":27,"_process":29}],17:[function(require,module,exports){
+},{"./adapters/http":12,"./adapters/xhr":12,"./helpers/normalizeHeaderName":32,"./utils":35,"_process":37}],25:[function(require,module,exports){
 'use strict';
 
 module.exports = function bind(fn, thisArg) {
@@ -1403,7 +1525,7 @@ module.exports = function bind(fn, thisArg) {
   };
 };
 
-},{}],18:[function(require,module,exports){
+},{}],26:[function(require,module,exports){
 'use strict';
 
 // btoa polyfill for IE<10 courtesy https://github.com/davidchambers/Base64.js
@@ -1441,7 +1563,7 @@ function btoa(input) {
 
 module.exports = btoa;
 
-},{}],19:[function(require,module,exports){
+},{}],27:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1511,7 +1633,7 @@ module.exports = function buildURL(url, params, paramsSerializer) {
   return url;
 };
 
-},{"./../utils":27}],20:[function(require,module,exports){
+},{"./../utils":35}],28:[function(require,module,exports){
 'use strict';
 
 /**
@@ -1527,7 +1649,7 @@ module.exports = function combineURLs(baseURL, relativeURL) {
     : baseURL;
 };
 
-},{}],21:[function(require,module,exports){
+},{}],29:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1582,7 +1704,7 @@ module.exports = (
   })()
 );
 
-},{"./../utils":27}],22:[function(require,module,exports){
+},{"./../utils":35}],30:[function(require,module,exports){
 'use strict';
 
 /**
@@ -1598,7 +1720,7 @@ module.exports = function isAbsoluteURL(url) {
   return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url);
 };
 
-},{}],23:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1668,7 +1790,7 @@ module.exports = (
   })()
 );
 
-},{"./../utils":27}],24:[function(require,module,exports){
+},{"./../utils":35}],32:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -1682,7 +1804,7 @@ module.exports = function normalizeHeaderName(headers, normalizedName) {
   });
 };
 
-},{"../utils":27}],25:[function(require,module,exports){
+},{"../utils":35}],33:[function(require,module,exports){
 'use strict';
 
 var utils = require('./../utils');
@@ -1737,7 +1859,7 @@ module.exports = function parseHeaders(headers) {
   return parsed;
 };
 
-},{"./../utils":27}],26:[function(require,module,exports){
+},{"./../utils":35}],34:[function(require,module,exports){
 'use strict';
 
 /**
@@ -1766,7 +1888,7 @@ module.exports = function spread(callback) {
   };
 };
 
-},{}],27:[function(require,module,exports){
+},{}],35:[function(require,module,exports){
 'use strict';
 
 var bind = require('./helpers/bind');
@@ -2071,7 +2193,7 @@ module.exports = {
   trim: trim
 };
 
-},{"./helpers/bind":17,"is-buffer":28}],28:[function(require,module,exports){
+},{"./helpers/bind":25,"is-buffer":36}],36:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -2094,7 +2216,7 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],29:[function(require,module,exports){
+},{}],37:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -2280,7 +2402,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],30:[function(require,module,exports){
+},{}],38:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -2366,7 +2488,7 @@ var isArray = Array.isArray || function (xs) {
   return Object.prototype.toString.call(xs) === '[object Array]';
 };
 
-},{}],31:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -2453,11 +2575,11 @@ var objectKeys = Object.keys || function (obj) {
   return res;
 };
 
-},{}],32:[function(require,module,exports){
+},{}],40:[function(require,module,exports){
 'use strict';
 
 exports.decode = exports.parse = require('./decode');
 exports.encode = exports.stringify = require('./encode');
 
-},{"./decode":30,"./encode":31}]},{},[1])(1)
+},{"./decode":38,"./encode":39}]},{},[1])(1)
 });

--- a/lib/account.js
+++ b/lib/account.js
@@ -149,6 +149,43 @@ module.exports = function(getRequest, apiKey) {
         module, action, address, apiKey
       });
       return getRequest(query);
+    },
+     /**
+     * [BETA] Get a list of "ERC20 - Token Transfer Events" by Address
+     * @param {string} address - Account address
+     * @param {string} startblock - start looking here
+     * @param {string} endblock - end looking there
+     * @param {string} sort - Sort asc/desc
+     * @param {string} contractaddress - Address of ERC20 token contract (if not specified lists transfers for all tokens)
+     * @example
+     * var txlist = api.account.tokentx('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', '0x5F988D968cb76c34C87e6924Cc1Ef1dCd4dE75da', 1, 'latest', 'asc');
+     * @returns {Promise.<object>}
+     */
+    tokentx(address, contractaddress, startblock, endblock, sort) {
+      const module = 'account';
+      const action = 'tokentx';
+
+      if (!startblock) {
+        startblock = 0;
+      }
+
+      if (!endblock) {
+        endblock = 'latest';
+      }
+
+      if (!sort) {
+        sort = 'asc';
+      }
+
+      var queryObject = {
+        module, action, startblock, endblock, sort, address, apiKey
+      };
+
+      if (contractaddress) {
+        queryObject.contractaddress = contractaddress;
+      }
+
+      return getRequest(querystring.stringify(queryObject));
     }
   };
 };

--- a/test/methods-test.js
+++ b/test/methods-test.js
@@ -76,6 +76,18 @@ describe('api', function() {
         done();
       });
     });
+    it('tokentx', function(done){
+      var api = init();
+      var txlist = api.account.tokentx(
+        '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae',
+        '0x6beb418fc6e1958204ac8baddcf109b8e9694966',
+        1, 'latest', 'asc'
+      );
+      txlist.then(function(res){
+        assert.ok(res);
+        done();
+      });
+    });
   });
   describe('stats', function(){
     it('ethsupply', function(done){

--- a/test/testnet-methods-test.js
+++ b/test/testnet-methods-test.js
@@ -47,6 +47,22 @@ describe('testnet methods', function () {
       }).catch(done);
     });
 
+    it('tokentx', function (done) {
+      /**
+       * No transaction found in testnet
+       * var txlist = api.account.txlist('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae');
+       */
+      var txlist = api.account.tokentx(
+        '0x293bae8584ed8df4a0319d95ffef5fb3645a22b6',
+        '0x4fa5333ecfe1afca2624e14b039268c4591ef8b9'
+      );
+
+      txlist.then(function (res) {
+        assert.ok(res);
+        done();
+      }).catch(done);
+    });
+
     xit('txlist', function (done) {
       /**
        * No transaction found in testnet


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Etherscan API now supports beta version ok `tokentx` actions in Account module which allows getting a list of "ERC20 - Token Transfer Events" by address and by token contract address.

https://etherscan.io/apis#accounts

## Description
<!--- Describe your changes in detail -->

- Added `tokentx` method in `account` module which accepts account address, contract address, block range and sort parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added test cases for a new method for mainnet and testnet.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (no linter warnings introduced).
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards --->
<!--- - fix/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of production) --->
