### PR TITLE
txlistinternal now utilizes user specified parameters  

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -85,14 +85,17 @@ module.exports = function(getRequest, apiKey) {
       if (!startblock) {
         startblock = 0;
       }
+      queryObject.startblock = startblock;
 
       if (!endblock) {
         endblock = 'latest';
       }
+      queryObject.endblock = endblock;
 
       if (!sort) {
         sort = 'asc';
       }
+      queryObject.sort = sort;
 
       if (txhash) {
         queryObject.txhash = txhash;


### PR DESCRIPTION
`txlistinternal` was not adding user passed in parameters: `startblock` , `endblock`, and `sort` to the query 

This change adds these user specified parameters to the `queryObject` before querying Etherscan.