### PR TITLE
Improve issue #42: showing meaning message instead of 'NOTOK'

### DIFF
--- a/lib/get-request.js
+++ b/lib/get-request.js
@@ -37,10 +37,11 @@ module.exports = function(chain, timeout) {
         var data = response.data;
 
         if (data.status && data.status != 1) {
-          let returnMessage = 'NOTOK';
+          let returnMessage = data.message ||'NOTOK';
           if (data.result && typeof data.result === 'string') {
             returnMessage = data.result;
           }
+          
           return reject(returnMessage);
         }
 

--- a/lib/get-request.js
+++ b/lib/get-request.js
@@ -41,7 +41,7 @@ module.exports = function(chain, timeout) {
           if (data.result && typeof data.result === 'string') {
             returnMessage = data.result;
           }
-          
+
           return reject(returnMessage);
         }
 


### PR DESCRIPTION
- This is a known-issued (#42 ).
- Currently if getting empty array result of transaction list of address, will throw an error with message 'NOTOK!' only and it is really hard to debug. 
- Base on my investigation in response format I think we can use `message = resp.data.message` as error message.