### PR TITLE
support for etherscan's tokennfttx api for ERC721 tokens

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -209,6 +209,54 @@ module.exports = function(getRequest, apiKey) {
       }
 
       return getRequest(querystring.stringify(queryObject));
-    }
+    },
+
+    /**
+    * [BETA] Get a list of "ERC721 - Token Transfer Events" by Address
+    * @param {string} address - Account address
+    * @param {string} startblock - start looking here
+    * @param {string} endblock - end looking there
+     * @param {number} page - Page number
+     * @param {number} offset - Max records to return
+     * @param {string} sort - Sort asc/desc
+    * @param {string} contractaddress - Address of ERC721 token contract (if not specified lists transfers for all tokens)
+    * @example
+    * var txlist = api.account.tokenftntx('0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', '0x5F988D968cb76c34C87e6924Cc1Ef1dCd4dE75da', 1, 'latest', 'asc');
+    * @returns {Promise.<object>}
+    */
+   tokennfttx(address, contractaddress, startblock, endblock, page, offset, sort) {
+     const module = 'account';
+     const action = 'tokennfttx';
+
+     if (!startblock) {
+       startblock = 0;
+     }
+
+     if (!endblock) {
+       endblock = 'latest';
+     }
+
+      if (!page) {
+        page = 1;
+      }
+
+      if (!offset) {
+        offset = 100;
+      }
+
+     if (!sort) {
+       sort = 'asc';
+     }
+
+     var queryObject = {
+       module, action, startblock, endblock, page, offset, sort, address, apiKey
+     };
+
+     if (contractaddress) {
+       queryObject.contractaddress = contractaddress;
+     }
+
+     return getRequest(querystring.stringify(queryObject));
+   }
   };
 };

--- a/test/methods-test.js
+++ b/test/methods-test.js
@@ -88,6 +88,18 @@ describe('api', function() {
         done();
       });
     });
+    it('tokennfttx', function(done){
+      var api = init();
+      var txlist = api.account.tokentx(
+        '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae',
+        '0x6beb418fc6e1958204ac8baddcf109b8e9694966',
+        1, 'latest', 'asc'
+      );
+      txlist.then(function(res){
+        assert.ok(res);
+        done();
+      });
+    });
   });
   describe('stats', function(){
     it('ethsupply', function(done){


### PR DESCRIPTION
change adds support for calling the api, similar to tokentx for ERC20 tokens