### PR TITLE
Add Goerli and Sepolia to the API URL list

### DIFF
--- a/lib/pick-chain-url.js
+++ b/lib/pick-chain-url.js
@@ -3,6 +3,8 @@ const OTHER_API_URL_MAP = {
   ropsten: 'https://api-ropsten.etherscan.io',
   kovan: 'https://api-kovan.etherscan.io',
   rinkeby: 'https://api-rinkeby.etherscan.io',
+  goerli: 'https://api-goerli.etherscan.io',
+  sepolia: 'https://api-sepolia.etherscan.io',
   homestead: 'https://api.etherscan.io',
   arbitrum: 'https://api.arbiscan.io',
   arbitrum_rinkeby: 'https://api-testnet.arbiscan.io'


### PR DESCRIPTION
Hey @sebs 

Thanks a lot for this amazing library.

I created this PR to include the Sepolia and Goerli API endpoints. Currently I'm creating the client (with `axios.create`) to support those two, but I'd be cool if I have directly included on the library.

Thanks!